### PR TITLE
Fix extraction for search result pages

### DIFF
--- a/sak32009-get-dlc-info-from-steamdb.user.js
+++ b/sak32009-get-dlc-info-from-steamdb.user.js
@@ -763,9 +763,9 @@ EXIT`;
     getData() {
 
         // SET APPID
-        this.steamDB.appID = $(".scope-app[data-appid]").data("appid");
+        this.steamDB.appID = this.info.isSearchPage ? $(".tab-pane.selected input#inputAppID").val() : $(".scope-app[data-appid]").data("appid");
         // SET APPID NAME
-        this.steamDB.appIDName = this.info.isSearchPage ? $("input#inputQuery").val().trim() : $("td[itemprop='name']").text().trim();
+        this.steamDB.appIDName = this.info.isSearchPage ? ($(".tab-pane.selected input#inputQuery").val() || "").trim() : $("td[itemprop='name']").text().trim();
 
         // SET APPID DLCs
         if (!this.info.isSearchPage) {
@@ -979,12 +979,13 @@ EXIT`;
 
                             const btnNext = $("#table-sortable_next");
 
+                            GetDLCInfofromSteamDB.getDataDLCS();
                             if (btnNext.hasClass("disabled")) {
                                 $("#GetDLCInfofromSteamDB_alertSearchPage").hide();
                                 window.clearInterval(interval);
+                                eventModalDom.open();
                             } else {
                                 btnNext.click();
-                                GetDLCInfofromSteamDB.getDataDLCS();
                             }
 
                         }, 500);


### PR DESCRIPTION
- Fixed a bug where the first page of search results would get ignored when gathering DLCs
- Added the ability to gather the AppID from "Linked Apps" searches
- Automatically open the dialog box after all search pages have been parsed

**NOTE:** This still can result in `steamDB.appID` being set to `undefined`. CreamAPI seems to handle this pretty gracefully (a helpful error message is shown). I haven't tested how the other formats cope, though.